### PR TITLE
(Bugfix) Resolve terminal bug by adding app variable

### DIFF
--- a/examples/api/auth-basic/app.js
+++ b/examples/api/auth-basic/app.js
@@ -15,7 +15,7 @@ var hyper = new Hyper(options);
 hyper.use(authBasic);
 
 // load config and routes
-hyper.start({
+var app = hyper.start({
     routes: [
         {
             api: "/hello",


### PR DESCRIPTION
Without specifying var app = hyper.start(...), the example loops continuously. 

Could alternatively be resolved by removing module.exports = app