### PR TITLE
(fix) Correctly export controllers of modules when Windows paths

### DIFF
--- a/legacy/manager.service.js
+++ b/legacy/manager.service.js
@@ -748,7 +748,8 @@ ServiceManager.export = function (serviceName) {
   var files = glob.sync(filePath + path.sep + 'controllers' + path.sep + '*.js');
   // console.log('files:', files);
   _.forEach(files, function (file) {
-    var parts = file.split(path.sep);
+    // "glob.sync" returns paths with normalized separators, so use "/" over path.sep here
+    var parts = file.split('/');
     var name = parts.pop();
     name = name.split('.')[0]; // remove '.js' from name
     service.controller[name] = {

--- a/lib/manager.service.js
+++ b/lib/manager.service.js
@@ -803,7 +803,8 @@ ServiceManager.export = function (serviceName) {
   var files = glob.sync(filePath + path.sep + 'controllers' + path.sep + '*.js');
     // console.log('files:', files);
   _.forEach(files, function (file) {
-    var parts = file.split(path.sep);
+    // "glob.sync" returns paths with normalized separators, so use "/" over path.sep here
+    var parts = file.split('/');
     var name = parts.pop();
     name = name.split('.')[0]; // remove '.js' from name
     service.controller[name] = {


### PR DESCRIPTION
Before this, the name of an exported controller would be identical to its absolute path when Windows, e.g.

**Unix**
/path/to/my/controller.js --> controller

**Windows**
C:/path/to/my/controller.js --> C:/path/to/my/controller