### PR TITLE
(fix) Bypass hyper.io req --> res pipeline when early response

### DIFF
--- a/lib/http.framework.express.js
+++ b/lib/http.framework.express.js
@@ -307,6 +307,11 @@ HttpFrameworkExpress.prototype.addWrappedMethodFunction = function (method, midd
 
     handler(this.buildInputs(req), req.session, req.cookies, req, res, next)
       .then(function (output) {
+        // do nothing if a response has already been sent
+        if (res.headersSent) {
+          return;
+        }
+
         // ---------------------------------------
         // TODO: Custom error format, defined in config
         if (responded) {

--- a/lib/service.middleware/apiviewRoutes.js
+++ b/lib/service.middleware/apiviewRoutes.js
@@ -273,6 +273,11 @@ class ApiViewRoutes extends ServiceMiddleware {
 
   // TODO: to many input, need some work
   _handlerWrapper (handlerFunc, resolved, skipOnError, service, controller, orgOutput) {
+    // do nothing if a response has already been sent
+    if (resolved['$rawResponse'].headersSent) {
+      return when.resolve({});
+    }
+
     if (!orgOutput) {
       orgOutput = { out: null, code: 200, headers: null };
     }


### PR DESCRIPTION
Hi Joe, hope things are well.  I'm working on something at the moment where I need to redirect to a login screen in a `$preRoute` handler.  e.g.

```js
async $preRoute($session, $rawResponse) {
    if (!$session || !$session.user) {
        $rawResponse.redirect('/login');
    }
}
```

The problem is I get this warning (non-breaking) in the server logs: 
```
Potentially unhandled rejection [3] Error: Can't render headers after they are sent to the client
    at ServerResponse.writeHead (_http_server.js:216:15)
    at ServerResponse.writeHead (/Users/noodle/project/server/node_modules/on-headers/index.js:55:19)
    at ServerResponse.writeHead (/Users/noodle/project/server/node_modules/on-headers/index.js:55:19)
    at ServerResponse.writeHead (/Users/noodle/project/server/node_modules/on-headers/index.js:55:19)
    at /Users/noodle/project/server/node_modules/hyper.io/lib/http.framework.express.js:358:13
    at tryCatchReject (/Users/noodle/project/server/node_modules/when/lib/makePromise.js:845:30)
    at runContinuation1 (/Users/noodle/project/server/node_modules/when/lib/makePromise.js:804:4)
    at Fulfilled.when (/Users/noodle/project/server/node_modules/when/lib/makePromise.js:592:4)
    at Pending.run (/Users/noodle/project/server/node_modules/when/lib/makePromise.js:483:13)
    at Scheduler._drain (/Users/noodle/project/server/node_modules/when/lib/Scheduler.js:62:19)
```
This happens because the handler at the end of the $preRoute --> route --> $postRoute promise chain will always call `res.writeHead`, which can only be called once.  So that rules out redirecting using `$rawResponse` directly.

Another solution I tried was using $error instead of $rawResponse.  e.g.

```js
async $preRoute($session, $error) {
    if (!$session || !$session.user) {
        $error(null, 302, { Location: '/login' });
        // return Promise.reject({});   <-- no effect
    }
}
```

However this doesn't work because the route --> $postRoute chain will still be invoked, since 302 isn't a 4xx or 5xx status code.  Thus, I get 302 responses with the content from the route, and without the Location header set (so no redirect).

**Solution 1**: The first solution is included in this PR.  It uses `$rawResponse.headersSent` to check if a response has already been sent.  If true, the extra handler pipeline logic will be bypassed.  This will make Attempt 1 above work.

**Solution 2**: Consider status codes >= 300 as error codes instead of only >= 400.  This will make Attempt 2 above work.

I prefer Solution 1 but its disadvantage is it couples *apiviewRoutes.js* to express.js, which I know is something you wanted to avoid.  What are your thoughts?